### PR TITLE
Create users and return user informations: email, full_name, token

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,9 +45,12 @@ end
 
 gem 'reform', '>= 2.2.0'
 gem 'reform-rails'
+gem 'roar'
 # Windows does not include zoneinfo files,
 # so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'trailblazer'
 gem 'trailblazer-rails'
+gem 'representable'
+gem 'multi_json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
+    multi_json (1.12.1)
     nio4r (2.0.0)
     nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
@@ -123,6 +124,8 @@ GEM
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
+    roar (1.1.0)
+      representable (~> 3.0.0)
     rubocop (0.48.1)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
@@ -172,11 +175,14 @@ PLATFORMS
 DEPENDENCIES
   byebug
   listen (>= 3.0.5, < 3.2)
+  multi_json
   pg (~> 0.18)
   puma (~> 3.7)
   rails (~> 5.1.0)
   reform (>= 2.2.0)
   reform-rails
+  representable
+  roar
   rubocop
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/concepts/user/contract/user_form.rb
+++ b/app/concepts/user/contract/user_form.rb
@@ -4,11 +4,13 @@ module User::Contract
   # Contract for user related form
   # it validates form's properties
   class UserForm < Reform::Form
+    VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i
+
     property :email
     property :full_name
     property :token
 
     validates :email, :full_name, :token, presence: true
-    validates :email, unique: true
+    validates :email, unique: true, format: VALID_EMAIL_REGEX
   end
 end

--- a/app/concepts/user/operation/create.rb
+++ b/app/concepts/user/operation/create.rb
@@ -5,17 +5,21 @@ class User::Create < Trailblazer::Operation
   step Contract::Validate()
   step Contract::Persist()
 
-  success :print_user_info
+  success :generate_json
+  failure :log_errors!
+
+  def log_errors!(options)
+    options['response.status'] = 422
+    options['presenter.default'] = {errors: options['contract.default'].errors.messages }
+  end
+
+  def generate_json(options)
+    options['response.status'] = 201
+    options['presenter.default'] = UserDecorator.new(options['model']).as_json
+  end
 
   # Check or generate token for user
   def ensure_token_generated!(options)
     options['model'].token ||= SecureRandom.hex
-  end
-
-  def print_user_info(options)
-    puts options['model'].id
-    puts options['model'].email
-    puts options['model'].full_name
-    puts options['model'].token
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,16 @@
 class ApplicationController < ActionController::API
+
+  include ActionController::HttpAuthentication::Token::ControllerMethods
+
+  before_action :authenticate
+
+  attr_reader :current_user
+
+  private
+
+  def authenticate
+    authenticate_with_http_token do |token, options|
+      @current_user = User.find_by(token: token)
+    end
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,40 @@
+class UsersController < ApplicationController
+
+  # Returns a list of recent projects for a given user
+  #
+  # POST /users
+  #
+  # params:
+  #   email - A valid and unique email address. Required field.
+  #   full_name - A full name of the user.
+  #
+  # = Examples
+  #
+  #   resp = post("/users", "email" => "irfandhk@gmail.com")
+  #
+  #   resp.status
+  #   => 200
+  #
+  #   resp.body
+  #   => { id: 1, email: 'irfandhk@gmail.com', full_name: 'Irfan Ahmed', token: 'dcbb7b36acd4438d07abafb8e28605a4' }
+  #
+  #   resp = conn.post("/users", email: 'irfandhk@gmail.com')
+  #
+  #   resp.status
+  #   => 422
+  #
+  #   resp.body
+  #   => { "errors": { "email": [ "has already been taken" ] } }
+  #
+  def create
+    @result = User::Create.(user_params)
+
+    render json: @result['presenter.default'], status: @result['response.status']
+  end
+
+  private
+  # Only allow a trusted parameter "white list" through.
+  def user_params
+    params.permit(:full_name, :email)
+  end
+end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,0 +1,10 @@
+require 'roar/decorator'
+require 'roar/json'
+
+class UserDecorator < Roar::Decorator
+  include Roar::JSON
+
+  property :full_name
+  property :email
+  property :token
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resources :users, only: [:create]
 end

--- a/test/concepts/user/operation/create_test.rb
+++ b/test/concepts/user/operation/create_test.rb
@@ -2,8 +2,8 @@ class CreateTest < ActiveSupport::TestCase
   test 'should create user record' do
     @user = User::Create.(
       full_name: 'Irfan Ahmed',
-      email: 'irfandhk@gmail.com',
-      token: SecureRandom.hex
+        email: 'irfandhk@gmail.com',
+        token: SecureRandom.hex
     )
 
     assert @user['model'].valid?
@@ -24,5 +24,16 @@ class CreateTest < ActiveSupport::TestCase
     )
 
     assert @user['contract.default'].errors.messages[:email].present?
+  end
+
+  test 'should validate email format' do
+    @user = User::Create.(
+      full_name: 'Irfan Ahmed',
+        email: 'irfandhkgmail.com'
+    )
+
+    assert @user['contract.default'].errors.messages[:email].present?
+
+    assert_equal @user['contract.default'].errors.messages[:email], ['is invalid']
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should create user with required input" do
+    assert_difference('User.count') do
+      post users_url, params: { email: 'irfandhk@gmail.com', full_name: 'Irfan Ahmed'}, as: :json
+    end
+
+    assert_response 201
+  end
+
+  test 'should not create user with incomplete input' do
+    post users_url, params: { email: 'irfandhk@gmail.com'}, as: :json
+
+    resp = JSON.parse(response.body)
+
+    assert_equal resp['errors']['full_name'], ["can't be blank"]
+    assert_response 422
+  end
+end


### PR DESCRIPTION
Added API endpoint to create users
- [x] Must provide all the require fields: email, full_name
- [x] Without required fields, response should return 422 status and details errors messages
- [x] Add format validation for users email